### PR TITLE
Stop banners from exceeding viewport width.

### DIFF
--- a/static_files/ghwikipp.css
+++ b/static_files/ghwikipp.css
@@ -14,6 +14,9 @@ body {
   font-weight: 300;
 }
 
+div.wikitopbanner, div.wikibottombanner {
+  width: auto;
+}
 
 table {
   border: 3px ridge #333;

--- a/static_files/ghwikipp.css
+++ b/static_files/ghwikipp.css
@@ -14,10 +14,6 @@ body {
   font-weight: 300;
 }
 
-div.wikitopbanner, div.wikibottombanner {
-  width: auto;
-}
-
 table {
   border: 3px ridge #333;
   border-collapse: collapse;
@@ -32,14 +28,14 @@ td {
   background-color: #BFC9D9;
   padding: 10px;
   margin-bottom: 10px;
-  width: 100%;
+  width: auto;
 }
 
 .wikibottombanner {
   background-color: #BFC9D9;
   padding: 10px;
   margin-top: 10px;
-  width: 100%;
+  width: auto;
 }
 
 /* Text and background color for dark mode */


### PR DESCRIPTION
![screenshot showcasing the scrollbar issue](https://i.imgur.com/3xLi2sC.png)
`wikitopbanner` and `wikibottombanner` `divs` were exceeding viewport width resulting in unnecessary horizontal scrollbar being added to the page window under a certain viewport width.
The banners always exceeded it by just a tiny bit so it's not like that scrollbar was even accomplishing anything.