### PR TITLE
Page padding.

### DIFF
--- a/static_files/ghwikipp.css
+++ b/static_files/ghwikipp.css
@@ -4,6 +4,7 @@
 
 /* Text and background color for light mode */
 body {
+  padding: 2vw;
   color: #333;
   max-width: 1200px;
   margin: 50px;


### PR DESCRIPTION
![padding comparison screenshot](https://i.imgur.com/5tsbneA.png)
![padding highlight screenshot](https://i.imgur.com/mxRT1DI.png)
To prevent text from "licking" the edges of the viewport on lower widths.
Doesn't break wrapping on obscenely-large screens you mentioned before.