### PR TITLE
Header filter now catches all headers lower than level 2

### DIFF
--- a/pandoc-filter.lua
+++ b/pandoc-filter.lua
@@ -9,7 +9,7 @@ function Link (link)
 end
 
 function Header(header)
-    if header.level == 2 then
+    if header.level >= 2 then
         local returnHeader = header
         returnHeader.attributes['class'] = 'anchorText'
         local svg = pandoc.Image('', '/static_files/link.svg')


### PR DESCRIPTION
This should fix the issue referenced at the end of thread #30  .