### PR TITLE
cleared up contrast tidbits, added auto-scaling for main page ui

### DIFF
--- a/static_files/ghwikipp.css
+++ b/static_files/ghwikipp.css
@@ -17,12 +17,11 @@ body {
   margin-right: auto;
   font-size: 16px;
   line-height: 1.3;
-  font-weight: 300;
   font-family: sans-serif;
 }
 
 a{
-  color: #7BA2C6;
+  color: #307ABD;
   text-decoration: none;
 }
 

--- a/templates/html_header
+++ b/templates/html_header
@@ -1,5 +1,6 @@
 <html><head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>@title@</title>
 <link rel="icon" type="image/ico" href="/static_files/favicon.ico" />
 <link rel="alternate" type="application/atom+xml" title="recent changes" href="@githuburl@/commits/@githubmainbranch@.atom" />


### PR DESCRIPTION
The contrast on the front page of the wiki is just horrendously low.

![image](https://user-images.githubusercontent.com/23583792/114772397-09203080-9d6e-11eb-9502-b2499d9838b0.png)

I can read the headings, the bold texts, and that's pretty much it.

This PR changes two CSS rules that makes it much more readable, by using a decent font weight (and not overly low), and sets a darker color for the links.

Additionally, this PR adds support for automatic UI scaling on mobile, to allow to have decently scaled pages instead of a "desktop view on mobile".