### PR TITLE
Update ghwikipp.css

### DIFF
--- a/static_files/ghwikipp.css
+++ b/static_files/ghwikipp.css
@@ -18,6 +18,7 @@ body {
   font-size: 16px;
   line-height: 1.3;
   font-family: sans-serif;
+  overflow-wrap: break-word;
 }
 
 a{


### PR DESCRIPTION
Updated body to include "    overflow-wrap: break-word;"  to fix pages like https://wiki.libsdl.org/SGWikiBasics going out of bounds