### PR TITLE
CSS adjustments (fixes, font settings, colours in dark mode, code styles)

### DIFF
--- a/static_files/ghwikipp.css
+++ b/static_files/ghwikipp.css
@@ -2,69 +2,70 @@
   color-scheme: dark light; /* both supported */
 }
 
-html {
-  background-color: aliceblue;
-  padding: 20px;
-}
-
 body {
   background-color: white;
   padding: 2vw;
   color: #333;
   max-width: 1200px;
-  margin: 50px;
-  margin-left: auto;
-  margin-right: auto;
+  margin: 0 auto;
   font-size: 16px;
-  line-height: 1.3;
-  font-family: sans-serif;
+  line-height: 1.5;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans",
+    Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
   overflow-wrap: break-word;
 }
 
-a{
-  color: #307ABD;
-  text-decoration: none;
+a {
+  color: #0969da;
+  /* text-decoration: none; */
 }
 
-h1{
+a:visited {
+  color: #064998;
+}
+
+h1 {
   border-bottom: 2px solid #efefef;
 }
 
-h2{
+h2 {
   border-bottom: 1px solid #efefef;
 }
 
-p{
+p {
   max-width: 85ch;
-  font-family: serif;
 }
 
-ul{
-  list-style-type: none;
-}
-
-li{
-  margin-top: 1em;
-  margin-bottom: 1em;
+li {
   max-width: 85ch;
-  font-family: serif;
 }
 
 div.sourceCode {
-  background-color: rgba(128, 128, 128, 0.2);
-  border: 0.3vmax ridge #333;
+  background-color: #f6f8fa;
   width: fit-content;
-  padding: 1vmax;
+  padding: 16px;
+}
+
+code {
+  background-color: #f6f8fa;
+  padding: 2px;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+    "Liberation Mono", monospace;
+  font-size: 90%;
 }
 
 table {
-  border: 3px ridge #333;
+  border: 1px solid #808080;
   border-collapse: collapse;
 }
 
 td {
-  border: 1px solid #333;
+  border: 1px solid #808080;
   padding: 5px;
+}
+
+tr:nth-child(even) {
+  background-color: #f6f8fa;
 }
 
 .wikitopbanner {
@@ -85,58 +86,85 @@ td {
   background-color: #f8d7da;
   border: 1px solid #f5c6cb;
   max-width: 60%;
-  line-height: 1.5em;
   padding: 10;
-  margin:auto;
+  margin: auto;
 }
 
 .anchorImage {
   visibility: hidden;
   padding-left: 0.2em;
+  color: #fff;
 }
 
-.anchorText {
-}
-
-.anchorText:hover .anchorImage{
+.anchorText:hover .anchorImage {
   visibility: visible;
 }
 
+hr {
+  display: block;
+  height: 1px;
+  border: 0;
+  border-top: 1px solid #efefef;
+  margin: 1em 0;
+  padding: 0;
+}
 
 /* Text and background color for dark mode */
 @media (prefers-color-scheme: dark) {
-  html {
-    background-color: #000022;
+  body {
+    color: #e6edf3;
+    background-color: #0d1117;
   }
 
-  body {
-    color: #adbac7;
-    background-color: #22272e;
+  h1 {
+    border-color: rgba(48, 54, 61, 0.7);
+  }
+
+  h2 {
+    border-color: rgba(48, 54, 61, 0.7);
+  }
+
+  hr {
+    border-color: rgba(48, 54, 61, 0.7);
   }
 
   div.sourceCode {
-    border-color: #AAA;
-    background-color: #232629;
+    background-color: #161b22;
+  }
+
+  code {
+    background-color: #161b22;
   }
 
   a {
-    color: #809fff;
-    text-decoration: none;
+    color: #4493f8;
+  }
+
+  a:visited {
+    color: #2f66ad;
   }
 
   table {
-    border: 3px ridge #AAAAAA;
+    border-color: rgba(48, 54, 61, 0.7);
   }
 
   td {
-    border: 1px solid #AAAAAA;
+    border-color: rgba(48, 54, 61, 0.7);
+  }
+
+  tr:nth-child(even) {
+    background-color: #161b22;
   }
 
   .wikitopbanner {
-    background-color: #4d6080;
+    background-color: #263040;
   }
 
   .wikibottombanner {
-    background-color: #4d6080;
+    background-color: #263040;
+  }
+
+  .anchorText:hover .anchorImage {
+    filter: invert(100%);
   }
 }


### PR DESCRIPTION
Hello!

Related to [this issue](https://github.com/libsdl-org/SDL/issues/9548), here are some CSS adjustments for the wiki. This has been tested on the latest versions of Safari, Chrome & Firefox on macOS.

Changes include:

- fixed the problem with bullets not being shown in lists (because of `list-style-type: none`)
- fixed a problem in dark mode where the "anchor image" (in headings) would be black on black background
- removed background colour (`aliceblue`) 
- removed the 50px margin at top of page (I thought this was a bit too much, especially when browsing on a mobile phone)
- set `line-height` to `1.5` like GitHub for readability
- uses system fonts by default (again, like GitHub): sans-serif for body, and monospace for code
- updated link colours to match those of GitHub (light/dark mode)
- the visited links have a darker colour (`a:visited`)
- removed `text-decoration: none` so that the links are underlined
- made the tables look like those on GitHub (with background-colour that alternates for each line)
- made the `<hr>` tags look like the other borders
- removed top/bottom margins for each list element
- removed empty selectors (html, .anchorText)
- updated colours in dark mode

Let me know if you want me to make some changes — I know some of those changes are just a matter of preference on my part.

Have a good day!

<img width="1270" alt="Capture d’écran 2024-04-17 à 12 55 29" src="https://github.com/libsdl-org/ghwikipp/assets/1141722/e219fe38-8a10-4e2a-b583-eecca7d854a0">
<img width="1262" alt="Capture d’écran 2024-04-17 à 12 56 21" src="https://github.com/libsdl-org/ghwikipp/assets/1141722/1eec3f75-4009-4e16-b2d0-616ae38dc5b8">
<img width="1241" alt="Capture d’écran 2024-04-17 à 12 56 32" src="https://github.com/libsdl-org/ghwikipp/assets/1141722/52d45fc8-5001-479d-9681-86b61e2c9c68">
<img width="774" alt="Capture d’écran 2024-04-17 à 12 57 33" src="https://github.com/libsdl-org/ghwikipp/assets/1141722/d7209738-68b2-4dd4-a454-efcc3b95d548">
<img width="1266" alt="Capture d’écran 2024-04-17 à 12 57 59" src="https://github.com/libsdl-org/ghwikipp/assets/1141722/6f846077-7dd9-47a8-a55d-ae82723caee1">