### PR TITLE
css: fix source code max-width for small screens + source code font-size

### DIFF
--- a/static_files/ghwikipp.css
+++ b/static_files/ghwikipp.css
@@ -42,7 +42,7 @@ li {
 
 div.sourceCode {
   background-color: #f6f8fa;
-  width: fit-content;
+  max-width: 100%;
   padding: 16px;
 }
 
@@ -51,7 +51,6 @@ code {
   padding: 2px;
   font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
     "Liberation Mono", monospace;
-  font-size: 90%;
 }
 
 table {


### PR DESCRIPTION
Hello!

This morning I was browsing the wiki on my iPhone and I saw two problems I did not see yesterday:

1. source code divs would not scroll on X overflow (this is a problem for smaller screens)
2. source code has an incorrect font-size (this is because of one of my changes yesterday)

Difference before/after the fix (on my iPhone):

BEFORE:

![IMG_3816](https://github.com/libsdl-org/ghwikipp/assets/1141722/4fbd8ce4-8c9a-4179-8eec-ee5c7fcd0f39)
![IMG_3817](https://github.com/libsdl-org/ghwikipp/assets/1141722/160a5427-82f0-420f-9921-d298abc73a9f)

AFTER:

![IMG_3818](https://github.com/libsdl-org/ghwikipp/assets/1141722/caa6b629-03c8-4680-bf75-6921e51d7a41)
![IMG_3819](https://github.com/libsdl-org/ghwikipp/assets/1141722/f4a7ad0d-9322-40dd-8d48-36b7e9f95100)


Have a good day