### PR TITLE
css: tweaks when printing

### DIFF
--- a/static_files/ghwikipp.css
+++ b/static_files/ghwikipp.css
@@ -168,3 +168,23 @@ hr {
     filter: invert(100%);
   }
 }
+
+@media print {
+  body {
+    font-size: 12px;
+  }
+
+  table {
+    font-size: inherit;
+  }
+
+  a:visited {
+    color: #0969da;
+  }
+
+  .wikitopbanner,
+  .anchorText,
+  .wikibottombanner {
+    display: none;
+  }
+}


### PR DESCRIPTION
Hello!

A recent comment [in SDL issue 9440](https://github.com/libsdl-org/SDL/issues/9440#issuecomment-2094654214) made me think that the wiki's CSS could use some tweaks when "printing" a page —  whether we're printing to paper or just output to PDF (which is more likely, I suppose?).

Here are the changes (only when printing):

- font-size is set to 12px (instead of 16px)
- visited links are not in a different colour
- header + footer (+ ".anchorText") are hidden

I did not hide the `[ edit | delete | history | feedback | raw ]` line because I could not select it easily. Putting this line in a span or div with a custom class (eg "editButtons") for example would make this easier to do.

"SDL_CreateWindow" page printed as PDF using Safari: [SDL3:SDL_CreateWindow - SDL Wiki.pdf](https://github.com/libsdl-org/ghwikipp/files/15212117/SDL3.SDL_CreateWindow.-.SDL.Wiki.pdf)

On another note, I'm wondering if outputting the contents of *all* wiki pages to a single HTML file and trying to output it as PDF from a browser would be a good idea. This would need some changes (such as rewriting links as anchors instead of URL to be able to navigate inside the PDF) but I guess that would fix some problems you had, like code blocks that run off the end of the paper.
I'm trying to tweak the `wikiheaders.pl` file, but I don't know perl so this takes time.

Have a good day